### PR TITLE
Fixes for Video support

### DIFF
--- a/Extensions/XEP-0166/XMPPJingle.h
+++ b/Extensions/XEP-0166/XMPPJingle.h
@@ -39,6 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSXMLElement*)getVideoContent:(NSString *)type  data:(NSDictionary *)data target:(XMPPJID *)target;
 
+- (NSString *) addSources:(NSString *)sources toJingle:(NSString *)jingle error:(NSError **)error;
+
 @end
 
 @protocol XMPPJingleDelegate <NSObject>

--- a/Extensions/XEP-0166/XMPPJingleSDP.h
+++ b/Extensions/XEP-0166/XMPPJingleSDP.h
@@ -29,6 +29,7 @@
 - (XMPPIQ *)CandidateToXMPP:(NSDictionary *)dict media:(NSString *)media action:(NSString *)action initiator:(XMPPJID *)initiator target:(XMPPJID *)target UID:(NSString *)UID SID:(NSString *)SID;
 - (NSXMLElement *)MediaToXMPP:(NSString *)type  data:(NSDictionary *)data target:(XMPPJID *)target UID:(NSString *)UID SID:(NSString *)SID;
 
+- (NSString *)XMPPElementToSDP:(XMPPElement *)iq;
 - (NSString *)XMPPToSDP:(XMPPIQ *)iq;
 - (NSDictionary *)XMPPToCandidate:(XMPPIQ *)iq;
 

--- a/Extensions/XEP-0166/XMPPJingleSDP.m
+++ b/Extensions/XEP-0166/XMPPJingleSDP.m
@@ -9,6 +9,8 @@
 #import "JAHConvertSDP.h"
 #define SDP_GROUP_XMLNS @"urn:xmpp:jingle:apps:grouping:0"
 
+#define SDP_APPLICATION_MEDIA_NAME @"data"
+
 @implementation XMPPJingleSDPUtil
 
 - (NSString *)parseGroups:(XMPPElement *)jElement
@@ -88,7 +90,7 @@
     NSArray *codeclist = [[content elementForName:@"description"] elementsForName:@"payload-type"];
 
     NSString *name = (NSString *)[content attributeStringValueForName:@"name"];
-    if ([name isEqualToString:@"data"]) {
+    if ([name isEqualToString:SDP_APPLICATION_MEDIA_NAME]) {
         [contentString appendFormat:@"m=application 1 UDP/DTLS/SCTP webrtc-datachannel"];
     } else {
         [contentString appendFormat:@"m=%@ 1 RTP/SAVPF", name];
@@ -538,7 +540,7 @@
             NSDictionary* description = [content objectForKey:@"description"];
             NSString* media_name = [description objectForKey:@"media"];
             if (media_name == nil || [media_name isEqualToString:@""] || [media_name isEqualToString:@"application"]) {
-                media_name = @"data";
+                media_name = SDP_APPLICATION_MEDIA_NAME;
             }
             
             NSXMLElement *groupContent = [NSXMLElement elementWithName:@"content"];
@@ -556,9 +558,9 @@
         NSDictionary* description = [content objectForKey:@"description"];
         NSString* media_name = [description objectForKey:@"media"];
         if (media_name == nil || [media_name isEqualToString:@""] || [media_name isEqualToString:@"application"]) {
-            media_name = @"data";
+            media_name = SDP_APPLICATION_MEDIA_NAME;
         }
-        if ([media_name isEqualToString:@"data"]) {
+        if ([media_name isEqualToString:SDP_APPLICATION_MEDIA_NAME]) {
             continue;
         }
         NSString *ssrc = [description objectForKey:@"ssrc"];
@@ -572,7 +574,7 @@
         //Description
         NSXMLElement *descElement = [NSXMLElement elementWithName:@"description"];
         [descElement addAttributeWithName:@"xmlns" stringValue:@"urn:xmpp:jingle:apps:rtp:1"];
-        if ([media_name isEqualToString:@"data"]) {
+        if ([media_name isEqualToString:SDP_APPLICATION_MEDIA_NAME]) {
             [descElement addAttributeWithName:@"media" stringValue:@"application"];
         } else {
             [descElement addAttributeWithName:@"media" stringValue:media_name];

--- a/Extensions/XEP-0166/XMPPJingleSDP.m
+++ b/Extensions/XEP-0166/XMPPJingleSDP.m
@@ -18,23 +18,6 @@
     NSMutableString *groupStr = [[NSMutableString alloc]init]; // TO be set once ready
     NSMutableArray *names = [[NSMutableArray alloc] init];
 
-    // Get group content
-   /* NSArray *groups = [[iq elementForName:@"jingle"] elementForName:@"group"];
-    if (groups != nil)
-    {
-        NSLog(@"Error in retrieving groups");
-    }
-    
-    NSMutableArray *names = [[NSMutableArray alloc] init];
-    NSXMLElement *group;
-    if ([groups count] > 0)
-    {
-        group = [[iq elementForName:@"jingle"] elementForName:@"group"];
-    }
-    else
-    {
-        group = (NSXMLElement *)[groups objectAtIndex:0];   // TBD: for multiple groups
-    }*/
     NSXMLElement *group;
 
     if (jElement == nil)
@@ -954,8 +937,6 @@
     NSXMLElement *contentElement = [NSXMLElement elementWithName:@"content"];
     [contentElement addAttributeWithName:@"creator" stringValue:@"responder"];
     [contentElement addAttributeWithName:@"name" stringValue:media];
-    
-    //NSXMLElement *transElement = transElement1;
     
     NSXMLElement *transElement = [NSXMLElement elementWithName:@"transport"];
     [transElement addAttributeWithName:@"xmlns" stringValue:@"urn:xmpp:jingle:transports:ice-udp:1"];

--- a/Extensions/XEP-0166/XMPPJingleSDP.m
+++ b/Extensions/XEP-0166/XMPPJingleSDP.m
@@ -556,8 +556,6 @@
         } else {
             [descElement addAttributeWithName:@"media" stringValue:media_name];
         }
-        if(ssrc)
-            [descElement addAttributeWithName:@"ssrc" stringValue:ssrc];
         
         //Payloads
         NSArray* payloads = [description objectForKey:@"payloads"];
@@ -681,6 +679,15 @@
                     [sourceElement addChild:paraElement];
                 }
                 
+                NSString *msid = [content objectForKey:@"msid"];
+                if (msid) {
+                    NSXMLElement *paraElement = [NSXMLElement elementWithName:@"parameter"];
+                    [paraElement addAttributeWithName:@"value" stringValue:msid];
+                    [paraElement addAttributeWithName:@"name" stringValue:@"msid"];
+                    
+                    [sourceElement addChild:paraElement];
+                }
+                
                 [descElement addChild:sourceElement];
             }
             
@@ -700,13 +707,11 @@
             NSDictionary *hdrext = [hdrexts objectAtIndex:z];
             NSString *uri = [hdrext objectForKey:@"uri"];
             NSString *strId = [hdrext objectForKey:@"id"];
-            NSString *senders = [hdrext objectForKey:@"senders"];
             
             NSXMLElement *hdrextElement = [NSXMLElement elementWithName:@"rtp-hdrext"];
             [hdrextElement addAttributeWithName:@"xmlns" stringValue:@"urn:xmpp:jingle:apps:rtp:rtp-hdrext:0"];
             [hdrextElement addAttributeWithName:@"uri" stringValue:uri];
             [hdrextElement addAttributeWithName:@"id" stringValue:strId];
-            [hdrextElement addAttributeWithName:@"senders" stringValue:senders];
             
             [descElement addChild:hdrextElement];
         }

--- a/Extensions/XEP-0166/XMPPJingleSDP.m
+++ b/Extensions/XEP-0166/XMPPJingleSDP.m
@@ -157,10 +157,6 @@
                 [sdp addObject:@"generation"];
                 [sdp addObject:[canElement attributeStringValueForName:@"generation"] ?: @"0"];
                 
-                if (ufrag) {
-                    [sdp addObject:[NSString stringWithFormat:@"ufrag %@", ufrag]];
-                }
-                
                 if ([canElement attributeStringValueForName:@"network"]) {
                     [sdp addObject:[NSString stringWithFormat:@"network-id %@", [canElement attributeStringValueForName:@"network"]]];
                 }
@@ -232,12 +228,14 @@
     }
     
     if (![name isEqualToString:@"data"] && ![name isEqualToString:@"application"]) {
-        [contentString appendFormat:@"a=msid:mixedmslabel mixedlabel%@0\r\n",name];
-        // Next line is rtcp-mux
-        if ([[content elementForName:@"description"] elementForName:@"rtcp-mux"] )
-        {
-            [contentString appendString:@"a=rtcp-mux\r\n"];
-        }
+        //[contentString appendFormat:@"a=msid:mixedmslabel mixedlabel%@0\r\n",name];
+    }
+    
+    // Next line is rtcp-mux
+    if ([[content elementForName:@"description"] elementForName:@"rtcp-mux"] )
+    {
+        [contentString appendString:@"a=rtcp-mux\r\n"];
+        [contentString appendString:@"a=rtcp-rsiz\r\n"];
     }
     
     // Next line is crypto
@@ -290,6 +288,10 @@
             {
                 NSString *name = [[parameters objectAtIndex:i] attributeStringValueForName:@"name"];
                 NSString *value = [[parameters objectAtIndex:i] attributeStringValueForName:@"value"];
+                
+                if([value hasSuffix:@";"]) {
+                    value = [value substringToIndex:value.length - 1];
+                }
                 
                 if (name && value)
                 {
@@ -416,11 +418,20 @@
                         [sdp addObject:[canElement attributeStringValueForName:@"relAddr"]];
                         [sdp addObject:@"rport"];
                         [sdp addObject:[canElement attributeStringValueForName:@"relPort"]];
+                    } else if ([canElement attributeStringValueForName:@"rel-addr"] && [canElement attributeStringValueForName:@"rel-port"]) {
+                        [sdp addObject:@"raddr"];
+                        [sdp addObject:[canElement attributeStringValueForName:@"rel-addr"]];
+                        [sdp addObject:@"rport"];
+                        [sdp addObject:[canElement attributeStringValueForName:@"rel-port"]];
                     }
                 }
                 
                 [sdp addObject:@"generation"];
                 [sdp addObject:[canElement attributeStringValueForName:@"generation"] ?: @"0"];
+                
+                if ([canElement attributeStringValueForName:@"network"]) {
+                    [sdp addObject:[NSString stringWithFormat:@"network-id %@", [canElement attributeStringValueForName:@"network"]]];
+                }
                 
                 [dict setObject:[@"a=candidate:" stringByAppendingString:[sdp componentsJoinedByString:@" "]] forKey:@"candidate"]; ;
 
@@ -656,10 +667,6 @@
                 NSXMLElement *sourceElement = [NSXMLElement elementWithName:@"source"];
                 [sourceElement addAttributeWithName:@"ssrc" stringValue:ssrc];
                 [sourceElement addAttributeWithName:@"xmlns" stringValue:@"urn:xmpp:jingle:apps:rtp:ssma:0"];
-                
-                NSXMLElement *infoElement = [NSXMLElement elementWithName:@"ssrc-info" xmlns:@"http://jitsi.org/jitmeet"];
-                [infoElement addAttributeWithName:@"owner" stringValue:[initiator full]];
-                [sourceElement addChild:infoElement];
                 
                 NSArray *parameters = [source objectForKey:@"parameters"];
                 


### PR DESCRIPTION
This PR tackles 3 major issues in the module that is parsing Jingle->SDP: 

- **[Fixes the parse of the muxing information for data channel](https://github.com/FutureWorkshops/XMPPFramework/compare/release/stc...FutureWorkshops:feature/video_call#diff-9ef69cf56a1472f062398288c7edf8aaR110)**
- **[Add the parse for source groups on media](https://github.com/FutureWorkshops/XMPPFramework/compare/release/stc...FutureWorkshops:feature/video_call#diff-9ef69cf56a1472f062398288c7edf8aaR181)**
- **[Improve source-add parse & operation](https://github.com/FutureWorkshops/XMPPFramework/compare/release/stc...FutureWorkshops:feature/video_call#diff-479d692434428b9139d91be117ff03cdR366)**