### PR TITLE
Enable P2P on XMPPFramework

### DIFF
--- a/Extensions/XEP-0166/XMPPJingle.h
+++ b/Extensions/XEP-0166/XMPPJingle.h
@@ -17,11 +17,11 @@
     NSString* to;
     XMPPStream *myStream;
     NSString *UID;
-    NSString *SID;
 }
 
 // delegate to post msg, TODO: managing queue for dispatching msgs
 @property(nonatomic, assign, nullable) id<XMPPJingleDelegate> delegate;
+@property(nonatomic, assign, readonly, nonnull) NSString *SID;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Extensions/XEP-0166/XMPPJingle.m
+++ b/Extensions/XEP-0166/XMPPJingle.m
@@ -29,6 +29,8 @@
 
 @implementation XMPPJingle
 
+@synthesize SID = _SID;
+
 #pragma mark - XMPP module related methods
 
 // Init
@@ -38,7 +40,7 @@
     enableLogging = NO;
     sdpUtil = [[XMPPJingleSDPUtil alloc]init];
     UID = [XMPPStream generateUUID];
-    SID = [[UID substringToIndex:12] lowercaseString];
+    _SID = [[UID substringToIndex:12] lowercaseString];
     return [self initWithDispatchQueue:NULL];
 }
 
@@ -49,7 +51,7 @@
     enableLogging = NO;
     sdpUtil = [[XMPPJingleSDPUtil alloc]init];
     UID = [XMPPStream generateUUID];
-    SID = [[UID substringToIndex:12] lowercaseString];
+    _SID = [[UID substringToIndex:12] lowercaseString];
     if ((self = [super initWithDispatchQueue:queue]))
     {
     }
@@ -171,13 +173,13 @@
     // Parse SDP
     if ([type isEqualToString:@"session-initiate"])
     {
-        XMPPIQ *sdp = [sdpUtil SDPToXMPP:[data objectForKey:@"sdp"] action:type initiator:[myStream myJID] target:target UID:UID SID:SID];
+        XMPPIQ *sdp = [sdpUtil SDPToXMPP:[data objectForKey:@"sdp"] action:type initiator:[myStream myJID] target:target UID:UID SID:_SID];
         if (sdp != nil)
             [myStream sendElement:sdp];
     }
     else if ([type isEqualToString:@"session-accept"])
     {
-        XMPPIQ *sdp = [sdpUtil SDPToXMPP:[data objectForKey:@"sdp"] action:type initiator:[myStream myJID] target:target UID:UID SID:SID];
+        XMPPIQ *sdp = [sdpUtil SDPToXMPP:[data objectForKey:@"sdp"] action:type initiator:[myStream myJID] target:target UID:UID SID:_SID];
         if (sdp != nil)
             [myStream sendElement:sdp];
     }
@@ -187,7 +189,7 @@
 
 - (NSXMLElement*) getVideoContent:(NSString *)type  data:(NSDictionary *)data target:(XMPPJID *)target
 {
-    return [sdpUtil MediaToXMPP:type data:data target:target UID:UID SID:SID];    
+    return [sdpUtil MediaToXMPP:type data:data target:target UID:UID SID:_SID];
 }
 
 // For Action (type) attribute: "transport-accept", "transport-info", "transport-reject", "transport-replace"
@@ -196,7 +198,7 @@
     // Parse SDP
     if ([type isEqualToString:@"transport-info"])
     {
-        XMPPIQ *candidate = [sdpUtil CandidateToXMPP:data media:nil action:type initiator:target/*[myStream myJID]*/ target:target UID:UID SID:SID];
+        XMPPIQ *candidate = [sdpUtil CandidateToXMPP:data media:nil action:type initiator:target/*[myStream myJID]*/ target:target UID:UID SID:_SID];
         if (candidate != nil)
             [myStream sendElement:candidate];
     }
@@ -247,7 +249,7 @@
     NSString *sessionid = [jingle attributeStringValueForName:@"sid"];
     if (sessionid)
     {
-        SID = sessionid;
+        _SID = sessionid;
     }
     
     NSString *bridgeSession = [[jingle elementForName:@"bridge-session" xmlns:@"http://jitsi.org/protocol/focus"] attributeStringValueForName:@"id"];
@@ -279,6 +281,18 @@
     [jsonDict setValue:iq.fromStr forKey:@"from"];
     [jsonDict setValue:iq.toStr forKey:@"to"];
     
+    XMPPElement *jingle = [iq elementForName:@"jingle" xmlns:XEP_0166_XMLNS];
+    
+    NSString *initiator = [jingle attributeStringValueForName:@"initiator"];
+    if (initiator) {
+        [jsonDict setValue:initiator forKey:@"initiator"];
+    }
+    [jsonDict setValue:jingle.XMLString forKey:@"jingle"];
+    
+    NSString *bridgeSession = [[jingle elementForName:@"bridge-session" xmlns:@"http://jitsi.org/protocol/focus"] attributeStringValueForName:@"id"];
+    if (bridgeSession) {
+        [jsonDict setValue:bridgeSession forKey:@"bridge-session"];
+    }
     
     // post the message to delegate
     [self.delegate didReceiveSessionMsg:sid type:@"session-accept" data:jsonDict];

--- a/Extensions/XEP-0166/XMPPJingle.m
+++ b/Extensions/XEP-0166/XMPPJingle.m
@@ -317,13 +317,15 @@
     NSDictionary *candidate = [sdpUtil XMPPToCandidate:iq];
     [candidate setValue:iq.fromStr forKey:@"from"];
     [candidate setValue:iq.toStr forKey:@"to"];
-    NSString *initiator = [[iq elementForName:@"jingle"] attributeStringValueForName:@"initiator"];
+    DDXMLElement *jingle = [iq elementForName:@"jingle"];
+    NSString *initiator = [jingle attributeStringValueForName:@"initiator"];
     if (initiator) {
         [candidate setValue:initiator forKey:@"initiator"];
     }
+    NSString *sid = [jingle attributeStringValueForName:@"sid"];
     
     // post the message to delegate
-    [self.delegate didReceiveTransportMsg:[candidate objectForKey:@"sid"] type:@"transport-info" data:candidate];
+    [self.delegate didReceiveTransportMsg:sid type:@"transport-info" data:candidate];
 }
 
 // Called when a transport-reject message is received

--- a/Extensions/XEP-0166/XMPPJingleSDP.m
+++ b/Extensions/XEP-0166/XMPPJingleSDP.m
@@ -543,9 +543,6 @@
         if (media_name == nil || [media_name isEqualToString:@""] || [media_name isEqualToString:@"application"]) {
             media_name = SDP_APPLICATION_MEDIA_NAME;
         }
-        if ([media_name isEqualToString:SDP_APPLICATION_MEDIA_NAME]) {
-            continue;
-        }
         NSString *ssrc = [description objectForKey:@"ssrc"];
         
         //Content


### PR DESCRIPTION
### Abstract

This is a necessary change to be able to do a peer-to-peer (P2P) connection on Jitsi.

### Changes

#### 1. Expose more data
*Commit: b08d726dfd362dc0a6f6d54597dadf01470a078f*

The first change was to expose more data from te Jingle protocol to the upper layers. Mainly, the session ID used in the communication. This will be used to see if the call is made to focus or P2P.

#### 2. Fix information data from transport-info
*Commit: 9debdce7604a3f5426a79aa8d490b8c45ed8f466*

The candidate information is passed between peer using a `transport-info` jingle message. This element had invalid and incomplete information. So, it was fixed, to propagate the correct object.

#### 3. Enable the traffic of media channel
*Commit: 283315d4d682afbe9a448e3a1b13f6d8cb4670e9*

The `data` media line was being removed from the SDP/XML conversion because Jitsi do not expects this channel information. But, for an 1-1 communication, this is a relevant information, since it is bundled together in the offer.


